### PR TITLE
Removing edit pipeline

### DIFF
--- a/exec_windows_edit.ps1
+++ b/exec_windows_edit.ps1
@@ -1,5 +1,0 @@
-param(
-    [string]$gauge_env = "js"
-)
-$env:PATH="$env:PATH;$env:GAUGE_ROOT" 
-gauge run --env=$gauge_env --tags='!knownIssue & actions_on_file_edit'

--- a/exec_windows_load.ps1
+++ b/exec_windows_load.ps1
@@ -2,4 +2,4 @@ param(
     [string]$gauge_env = "js"
 )
 $env:PATH="$env:PATH;$env:GAUGE_ROOT" 
-gauge run --env=$gauge_env --tags='!knownIssue & actions_on_project_load & actions_on_file_edit'
+gauge run --env=$gauge_env --tags='!knownIssue & (actions_on_project_load | actions_on_file_edit)'

--- a/exec_windows_load.ps1
+++ b/exec_windows_load.ps1
@@ -2,4 +2,4 @@ param(
     [string]$gauge_env = "js"
 )
 $env:PATH="$env:PATH;$env:GAUGE_ROOT" 
-gauge run --env=$gauge_env --tags='!knownIssue & actions_on_project_load'
+gauge run --env=$gauge_env --tags='!knownIssue & actions_on_project_load & actions_on_file_edit'


### PR DESCRIPTION
- Deleted `exec_windows_edit.ps1` file for windows
- Modifies tags to include `actions_on_file_edit` in load file.