### PR TITLE
Fix `bundle --path` warnings

### DIFF
--- a/tests/lsp/runner.js
+++ b/tests/lsp/runner.js
@@ -22,7 +22,8 @@ function prerequisite(projectPath, runner) {
         var result = fileContent.replace(/gem 'gauge-ruby'.*:group => \[:development, :test\]/, newContent);
         file.write(gemFilePath, result);
         var vendorFolderPath = path.join(process.cwd(), "data", "vendor");
-        execSync('bundle install --path ' + vendorFolderPath, { encoding: 'utf8', cwd: projectPath });
+        execSync('bundle config set --local path ' + vendorFolderPath, { encoding: 'utf8', cwd: projectPath });
+        execSync('bundle install', { encoding: 'utf8', cwd: projectPath });
     }
 }
 


### PR DESCRIPTION
Using of --path now emits many warnings while running the tests which is painful to grok. One is supposed to use bundle config now.

Still trying to fix/update `gauge-ruby` :-)